### PR TITLE
add graph publisher, responsible to send updates to stateful storage

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -68,9 +68,14 @@ import { QueueConstants } from '../../../libs/common/src';
       // disable throwing uncaughtException if an error event is emitted and it has no listeners
       ignoreErrors: false,
     }),
-    BullModule.registerQueue({
-      name: QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE,
-    }),
+    BullModule.registerQueue(
+      {
+        name: QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE,
+      },
+      {
+        name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
+      },
+    ),
     // Bullboard UI
     BullBoardModule.forRoot({
       route: '/queues',
@@ -78,6 +83,10 @@ import { QueueConstants } from '../../../libs/common/src';
     }),
     BullBoardModule.forFeature({
       name: QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+    BullBoardModule.forFeature({
+      name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
       adapter: BullMQAdapter,
     }),
     ScheduleModule.forRoot(),

--- a/apps/worker/src/graph_publisher/graph.publisher.processor.module.ts
+++ b/apps/worker/src/graph_publisher/graph.publisher.processor.module.ts
@@ -1,0 +1,56 @@
+/*
+https://docs.nestjs.com/modules
+*/
+
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
+import { ConfigModule } from '../../../../libs/common/src/config/config.module';
+import { ConfigService } from '../../../../libs/common/src/config/config.service';
+import { QueueConstants } from '../../../../libs/common/src';
+import { GraphUpdatePublisherService } from './graph.publisher.processor.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    RedisModule.forRootAsync(
+      {
+        imports: [ConfigModule],
+        useFactory: (configService: ConfigService) => ({
+          config: [{ url: configService.redisUrl.toString() }],
+        }),
+        inject: [ConfigService],
+      },
+      true, // isGlobal
+    ),
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => {
+        // Note: BullMQ doesn't honor a URL for the Redis connection, and
+        // JS URL doesn't parse 'redis://' as a valid protocol, so we fool
+        // it by changing the URL to use 'http://' in order to parse out
+        // the host, port, username, password, etc.
+        // We could pass REDIS_HOST, REDIS_PORT, etc, in the environment, but
+        // trying to keep the # of environment variables from proliferating
+        const url = new URL(configService.redisUrl.toString().replace(/^redis[s]*/, 'http'));
+        const { hostname, port, username, password, pathname } = url;
+        return {
+          connection: {
+            host: hostname || undefined,
+            port: port ? Number(port) : undefined,
+            username: username || undefined,
+            password: password || undefined,
+            db: pathname?.length > 1 ? Number(pathname.slice(1)) : undefined,
+          },
+        };
+      },
+      inject: [ConfigService],
+    }),
+    BullModule.registerQueue({
+      name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
+    }),
+  ],
+  providers: [GraphUpdatePublisherService],
+  exports: [BullModule, GraphUpdatePublisherService],
+})
+export class GraphUpdatePublisherModule {}

--- a/apps/worker/src/graph_publisher/graph.publisher.processor.service.ts
+++ b/apps/worker/src/graph_publisher/graph.publisher.processor.service.ts
@@ -1,0 +1,31 @@
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import { Processor } from '@nestjs/bullmq';
+import { Injectable } from '@nestjs/common';
+import { Job } from 'bullmq';
+import Redis from 'ioredis';
+import { Update } from '@dsnp/graph-sdk';
+import { ConfigService } from '../../../../libs/common/src/config/config.service';
+import { QueueConstants } from '../../../../libs/common/src';
+import { BaseConsumer } from '../BaseConsumer';
+
+@Injectable()
+@Processor(QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE)
+export class GraphUpdatePublisherService extends BaseConsumer {
+  constructor(
+    @InjectRedis() private cacheManager: Redis,
+    private configService: ConfigService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<Update, any, string>): Promise<any> {
+    this.logger.log(`Processing job ${job.id} of type ${job.name}`);
+    try {
+      // TODO: add logic to process graph change requests
+      this.logger.debug(job.asJSON());
+    } catch (e) {
+      this.logger.error(e);
+      throw e;
+    }
+  }
+}

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -8,6 +8,8 @@ import { RequestProcessorModule } from './request_processor/request.processor.mo
 import { RequestProcessorService } from './request_processor/request.processor.service';
 import { ConfigModule } from '../../../libs/common/src/config/config.module';
 import { ConfigService } from '../../../libs/common/src/config/config.service';
+import { GraphUpdatePublisherModule } from './graph_publisher/graph.publisher.processor.module';
+import { GraphUpdatePublisherService } from './graph_publisher/graph.publisher.processor.service';
 
 @Module({
   imports: [
@@ -44,7 +46,8 @@ import { ConfigService } from '../../../libs/common/src/config/config.service';
     ScheduleModule.forRoot(),
     BlockchainModule,
     RequestProcessorModule,
+    GraphUpdatePublisherModule,
   ],
-  providers: [ConfigService, RequestProcessorService],
+  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService],
 })
 export class WorkerModule {}

--- a/libs/common/src/utils/queues.ts
+++ b/libs/common/src/utils/queues.ts
@@ -3,4 +3,9 @@ export namespace QueueConstants {
    * Name of the queue that has all incoming requests
    */
   export const GRAPH_CHANGE_REQUEST_QUEUE = 'graphChangeRequest';
+
+  /**
+   * Name of the queue that publishes graph changes to Frequency blockchain
+   */
+  export const GRAPH_CHANGE_PUBLISH_QUEUE = 'graphChangePublish';
 }


### PR DESCRIPTION
## Details

Graph publisher processor will receieve `Update` types job (coming from graphsdk) and will be responsible to send updates to Frequency

- [x] Add a placeholder worker module for `graph publisher`
- [x] Add necessary bindings to types being received 

Closes #9 