### PR TITLE
Optional reconnection service

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -3,6 +3,7 @@ FREQUENCY_URL=ws://0.0.0.0:9944
 REDIS_URL=redis://0.0.0.0:6379
 QUEUE_HIGH_WATER=1000
 API_PORT=3000
+RECONNECTION_SERVICE_REQUIRED=false
 
 # Add the graph environment type. This can be 'Dev' or 'Rococo' or 'Mainnet'.
 GRAPH_ENVIRONMENT_TYPE=Dev

--- a/.env.dev
+++ b/.env.dev
@@ -4,6 +4,7 @@ REDIS_URL=redis://0.0.0.0:6379
 QUEUE_HIGH_WATER=1000
 API_PORT=3000
 RECONNECTION_SERVICE_REQUIRED=false
+BLOCKCHAIN_SCAN_INTERVAL_MINUTES=5
 
 # Add the graph environment type. This can be 'Dev' or 'Rococo' or 'Mainnet'.
 GRAPH_ENVIRONMENT_TYPE=Dev
@@ -13,3 +14,4 @@ GRAPH_ENVIRONMENT_TYPE=Dev
 # Be careful to escape any inner quotes as this is in a .env file.
 GRAPH_ENVIRONMENT_DEV_CONFIG='{"sdkMaxStaleFriendshipDays":100,"maxPageId":100,"dsnpVersions":["1.0"],"maxGraphPageSizeBytes":100,"maxKeyPageSizeBytes":100,"schemaMap":{"1":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"public"},"3":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"private"},"4":{"dsnpVersion":"1.0","connectionType":"friendship","privacyType":"private"}},"graphPublicKeySchemaId":5}'
 PROVIDER_ACCOUNT_SEED_PHRASE="//Ferdie"
+PROVIDER_ID=1

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ web_modules/
 
 # dotenv environment variable files
 .env
-.env.development.local
+.env.dev
 .env.test.local
 .env.production.local
 .env.local

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -75,6 +75,12 @@ import { QueueConstants } from '../../../libs/common/src';
       {
         name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
       },
+      {
+        name: QueueConstants.GRAPH_CHANGE_NOTIFY_QUEUE,
+      },
+      {
+        name: QueueConstants.RECONNECT_REQUEST_QUEUE,
+      },
     ),
     // Bullboard UI
     BullBoardModule.forRoot({
@@ -87,6 +93,14 @@ import { QueueConstants } from '../../../libs/common/src';
     }),
     BullBoardModule.forFeature({
       name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+    BullBoardModule.forFeature({
+      name: QueueConstants.GRAPH_CHANGE_NOTIFY_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+    BullBoardModule.forFeature({
+      name: QueueConstants.RECONNECT_REQUEST_QUEUE,
       adapter: BullMQAdapter,
     }),
     ScheduleModule.forRoot(),

--- a/apps/worker/src/reconnection_processor/graph.reconnection.processor.module.ts
+++ b/apps/worker/src/reconnection_processor/graph.reconnection.processor.module.ts
@@ -1,0 +1,56 @@
+/*
+https://docs.nestjs.com/modules
+*/
+
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
+import { ConfigModule } from '../../../../libs/common/src/config/config.module';
+import { ConfigService } from '../../../../libs/common/src/config/config.service';
+import { QueueConstants } from '../../../../libs/common/src';
+import { GraphReconnectionService } from './graph.reconnection.processor.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    RedisModule.forRootAsync(
+      {
+        imports: [ConfigModule],
+        useFactory: (configService: ConfigService) => ({
+          config: [{ url: configService.redisUrl.toString() }],
+        }),
+        inject: [ConfigService],
+      },
+      true, // isGlobal
+    ),
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => {
+        // Note: BullMQ doesn't honor a URL for the Redis connection, and
+        // JS URL doesn't parse 'redis://' as a valid protocol, so we fool
+        // it by changing the URL to use 'http://' in order to parse out
+        // the host, port, username, password, etc.
+        // We could pass REDIS_HOST, REDIS_PORT, etc, in the environment, but
+        // trying to keep the # of environment variables from proliferating
+        const url = new URL(configService.redisUrl.toString().replace(/^redis[s]*/, 'http'));
+        const { hostname, port, username, password, pathname } = url;
+        return {
+          connection: {
+            host: hostname || undefined,
+            port: port ? Number(port) : undefined,
+            username: username || undefined,
+            password: password || undefined,
+            db: pathname?.length > 1 ? Number(pathname.slice(1)) : undefined,
+          },
+        };
+      },
+      inject: [ConfigService],
+    }),
+    BullModule.registerQueue({
+      name: QueueConstants.RECONNECT_REQUEST_QUEUE,
+    }),
+  ],
+  providers: [GraphReconnectionService],
+  exports: [BullModule, GraphReconnectionService],
+})
+export class GraphReconnectionModule {}

--- a/apps/worker/src/reconnection_processor/graph.reconnection.processor.service.ts
+++ b/apps/worker/src/reconnection_processor/graph.reconnection.processor.service.ts
@@ -6,7 +6,6 @@ import Redis from 'ioredis';
 import { ConfigService } from '../../../../libs/common/src/config/config.service';
 import { IGraphUpdateJob, QueueConstants } from '../../../../libs/common/src';
 import { BaseConsumer } from '../BaseConsumer';
-import { ITxMonitorJob } from '../../../../libs/common/src/dtos/graph.notifier.job';
 
 @Injectable()
 @Processor(QueueConstants.RECONNECT_REQUEST_QUEUE)

--- a/apps/worker/src/reconnection_processor/graph.reconnection.processor.service.ts
+++ b/apps/worker/src/reconnection_processor/graph.reconnection.processor.service.ts
@@ -1,0 +1,31 @@
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import { Processor } from '@nestjs/bullmq';
+import { Injectable } from '@nestjs/common';
+import { Job } from 'bullmq';
+import Redis from 'ioredis';
+import { ConfigService } from '../../../../libs/common/src/config/config.service';
+import { IGraphUpdateJob, QueueConstants } from '../../../../libs/common/src';
+import { BaseConsumer } from '../BaseConsumer';
+import { ITxMonitorJob } from '../../../../libs/common/src/dtos/graph.notifier.job';
+
+@Injectable()
+@Processor(QueueConstants.RECONNECT_REQUEST_QUEUE)
+export class GraphReconnectionService extends BaseConsumer {
+  constructor(
+    @InjectRedis() private cacheManager: Redis,
+    private configService: ConfigService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<IGraphUpdateJob, any, string>): Promise<any> {
+    this.logger.log(`Processing job ${job.id} of type ${job.name}`);
+    try {
+      // TODO: add logic to process reconnection job and queue to request processor
+      this.logger.debug(job.asJSON());
+    } catch (e) {
+      this.logger.error(e);
+      throw e;
+    }
+  }
+}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -54,7 +54,7 @@ services:
     ports:
       - 3000:3000
     env_file:
-      - .env.docker.dev
+      - .env.dev
     environment:
       - START_PROCESS=api
       - REDIS_URL=redis://redis:6379
@@ -71,7 +71,7 @@ services:
       context: .
       dockerfile: dev.Dockerfile
     env_file:
-      - .env.docker.dev
+      - .env.dev
     environment:
       - START_PROCESS=worker
       - REDIS_URL=redis://redis:6379

--- a/env.template
+++ b/env.template
@@ -4,6 +4,7 @@ REDIS_URL=redis://0.0.0.0:6379
 QUEUE_HIGH_WATER=1000
 API_PORT=3000
 RECONNECTION_SERVICE_REQUIRED=false
+BLOCKCHAIN_SCAN_INTERVAL_MINUTES=5
 
 # Add the graph environment type. This can be 'Dev' or 'Rococo' or 'Mainnet'.
 GRAPH_ENVIRONMENT_TYPE=Dev
@@ -13,3 +14,4 @@ GRAPH_ENVIRONMENT_TYPE=Dev
 # Be careful to escape any inner quotes as this is in a .env file.
 GRAPH_ENVIRONMENT_DEV_CONFIG='{"sdkMaxStaleFriendshipDays":100,"maxPageId":100,"dsnpVersions":["1.0"],"maxGraphPageSizeBytes":100,"maxKeyPageSizeBytes":100,"schemaMap":{"1":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"public"},"3":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"private"},"4":{"dsnpVersion":"1.0","connectionType":"friendship","privacyType":"private"}},"graphPublicKeySchemaId":5}'
 PROVIDER_ACCOUNT_SEED_PHRASE="//Alice"
+PROVIDER_ID=1

--- a/env.template
+++ b/env.template
@@ -3,6 +3,7 @@ FREQUENCY_URL=ws://0.0.0.0:9944
 REDIS_URL=redis://0.0.0.0:6379
 QUEUE_HIGH_WATER=1000
 API_PORT=3000
+RECONNECTION_SERVICE_REQUIRED=false
 
 # Add the graph environment type. This can be 'Dev' or 'Rococo' or 'Mainnet'.
 GRAPH_ENVIRONMENT_TYPE=Dev

--- a/libs/common/src/blockchain/blockchain-scanner.service.ts
+++ b/libs/common/src/blockchain/blockchain-scanner.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { BlockHash } from '@polkadot/types/interfaces';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { MILLISECONDS_PER_SECOND, SECONDS_PER_MINUTE } from 'time-constants';
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import Redis from 'ioredis';
+import { ConfigService } from '../config/config.service';
+import { BlockchainService } from './blockchain.service';
+import { QueueConstants } from '../utils/queues';
+import { UpdateTransitiveGraphs, createReconnectionJob } from '../dtos/graph-update-job.interface';
+
+export const LAST_SEEN_BLOCK_NUMBER_KEY = 'lastSeenBlockNumber';
+
+@Injectable()
+export class BlockchainScannerService implements OnApplicationBootstrap {
+  private logger: Logger;
+
+  private scanInProgress = false;
+
+  async onApplicationBootstrap() {
+    if (this.configService.getReconnectionServiceRequired()) {
+      // Set up recurring interval
+      const interval = setInterval(() => this.scan(), this.configService.getBlockchainScanIntervalMinutes() * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND);
+      this.schedulerRegistry.addInterval('blockchainScan', interval);
+
+      // Kick off initial scan
+      const initialTimeout = setTimeout(() => this.scan(), 0);
+      this.schedulerRegistry.addTimeout('initialScan', initialTimeout);
+    }
+  }
+
+  constructor(
+    @InjectRedis() private cacheManager: Redis,
+    @InjectQueue(QueueConstants.RECONNECT_REQUEST_QUEUE) private reconnectionQueue: Queue,
+    private readonly configService: ConfigService,
+    private schedulerRegistry: SchedulerRegistry,
+    private blockchainService: BlockchainService,
+  ) {
+    this.logger = new Logger(BlockchainScannerService.name);
+  }
+
+  public async scan(): Promise<void> {
+    try {
+      if (this.scanInProgress) {
+        this.logger.log('Scheduled blockchain scan skipped due to previous scan still in progress');
+        return;
+      }
+
+      // Only scan blocks if queue is empty
+      let queueSize = await this.reconnectionQueue.count();
+      if (queueSize > 0) {
+        this.logger.log('Deferring next blockchain scan until queue is empty');
+        return;
+      }
+
+      this.scanInProgress = true;
+      let currentBlockNumber: bigint;
+      let currentBlockHash: BlockHash;
+
+      const lastSeenBlockNumber = await this.getLastSeenBlockNumber();
+      currentBlockNumber = lastSeenBlockNumber + 1n;
+      currentBlockHash = await this.blockchainService.getBlockHash(currentBlockNumber);
+
+      if (!currentBlockHash.some((byte) => byte !== 0)) {
+        this.logger.log('No new blocks to read; no scan performed.');
+        this.scanInProgress = false;
+        return;
+      }
+      this.logger.log(`Starting scan from block #${currentBlockNumber} (${currentBlockHash})`);
+
+      while (!currentBlockHash.isEmpty && queueSize < this.configService.getQueueHighWater()) {
+        // eslint-disable-next-line no-await-in-loop
+        const events = (await this.blockchainService.queryAt(currentBlockHash, 'system', 'events')).toArray();
+
+        const filteredEvents = events.filter(
+          ({ event }) => this.blockchainService.api.events.msa.DelegationGranted.is(event) && event.data.providerId.eq(this.configService.getProviderId()),
+        );
+
+        if (filteredEvents.length > 0) {
+          this.logger.debug(`Found ${filteredEvents.length} delegations at block #${currentBlockNumber}`);
+        }
+        const jobs = filteredEvents.map(async ({ event }) => {
+          const { key: jobId, data } = createReconnectionJob(event.data.delegatorId, event.data.providerId, UpdateTransitiveGraphs);
+          const job = await this.reconnectionQueue.getJob(jobId);
+          if (job && ((await job.isCompleted()) || (await job.isFailed()))) {
+            await job.retry();
+          } else {
+            await this.reconnectionQueue.add(`graphUpdate:${data.dsnpId}`, data, { jobId });
+          }
+        });
+
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.all(jobs);
+        // eslint-disable-next-line no-await-in-loop
+        await this.saveProgress(currentBlockNumber);
+
+        // Move to the next block
+        currentBlockNumber += 1n;
+        // eslint-disable-next-line no-await-in-loop
+        currentBlockHash = await this.blockchainService.getBlockHash(currentBlockNumber);
+        // eslint-disable-next-line no-await-in-loop
+        queueSize = await this.reconnectionQueue.count();
+      }
+
+      if (currentBlockHash.isEmpty) {
+        this.logger.log(`Scan reached end-of-chain at block ${currentBlockNumber - 1n}`);
+      } else if (queueSize > this.configService.getQueueHighWater()) {
+        this.logger.log('Queue soft limit reached; pausing scan until next iteration');
+      }
+    } catch (e) {
+      this.logger.error(JSON.stringify(e));
+      throw e;
+    } finally {
+      this.scanInProgress = false;
+    }
+  }
+
+  private async saveProgress(blockNumber: bigint): Promise<void> {
+    await this.setLastSeenBlockNumber(blockNumber);
+  }
+
+  public async getLastSeenBlockNumber(): Promise<bigint> {
+    return BigInt(((await this.cacheManager.get(LAST_SEEN_BLOCK_NUMBER_KEY)) ?? 0).toString());
+  }
+
+  private async setLastSeenBlockNumber(b: bigint): Promise<void> {
+    await this.cacheManager.set(LAST_SEEN_BLOCK_NUMBER_KEY, b.toString());
+  }
+}

--- a/libs/common/src/config/config.service.spec.ts
+++ b/libs/common/src/config/config.service.spec.ts
@@ -41,9 +41,11 @@ describe('GraphSericeConfig', () => {
     QUEUE_HIGH_WATER: undefined,
     API_PORT: undefined,
     RECONNECTION_SERVICE_REQUIRED: undefined,
+    BLOCKCHAIN_SCAN_INTERVAL_MINUTES: undefined,
     GRAPH_ENVIRONMENT_TYPE: undefined,
     GRAPH_ENVIRONMENT_DEV_CONFIG: undefined,
     PROVIDER_ACCOUNT_SEED_PHRASE: undefined,
+    PROVIDER_ID: undefined,
   };
 
   beforeAll(() => {
@@ -119,6 +121,10 @@ describe('GraphSericeConfig', () => {
       expect(graphServiceConfig.getReconnectionServiceRequired()).toStrictEqual(ALL_ENV.RECONNECTION_SERVICE_REQUIRED === 'true');
     });
 
+    it('should get blockchain scan interval minutes', () => {
+      expect(graphServiceConfig.getBlockchainScanIntervalMinutes()).toStrictEqual(parseInt(ALL_ENV.BLOCKCHAIN_SCAN_INTERVAL_MINUTES as string, 10));
+    });
+
     it('should get graph environment type', () => {
       expect(graphServiceConfig.getGraphEnvironmentType()).toStrictEqual(ALL_ENV.GRAPH_ENVIRONMENT_TYPE);
     });
@@ -129,6 +135,10 @@ describe('GraphSericeConfig', () => {
 
     it('should get provider account seed phrase', () => {
       expect(graphServiceConfig.getProviderAccountSeedPhrase()).toStrictEqual(ALL_ENV.PROVIDER_ACCOUNT_SEED_PHRASE);
+    });
+
+    it('should get provider id', () => {
+      expect(graphServiceConfig.getProviderId()).toStrictEqual(ALL_ENV.PROVIDER_ID);
     });
   });
 });

--- a/libs/common/src/config/config.service.spec.ts
+++ b/libs/common/src/config/config.service.spec.ts
@@ -40,6 +40,7 @@ describe('GraphSericeConfig', () => {
     FREQUENCY_URL: undefined,
     QUEUE_HIGH_WATER: undefined,
     API_PORT: undefined,
+    RECONNECTION_SERVICE_REQUIRED: undefined,
     GRAPH_ENVIRONMENT_TYPE: undefined,
     GRAPH_ENVIRONMENT_DEV_CONFIG: undefined,
     PROVIDER_ACCOUNT_SEED_PHRASE: undefined,
@@ -112,6 +113,10 @@ describe('GraphSericeConfig', () => {
 
     it('should get api port', () => {
       expect(graphServiceConfig.getApiPort()).toStrictEqual(parseInt(ALL_ENV.API_PORT as string, 10));
+    });
+
+    it('should get reconnection service required', () => {
+      expect(graphServiceConfig.getReconnectionServiceRequired()).toStrictEqual(ALL_ENV.RECONNECTION_SERVICE_REQUIRED === 'true');
     });
 
     it('should get graph environment type', () => {

--- a/libs/common/src/config/config.service.ts
+++ b/libs/common/src/config/config.service.ts
@@ -12,9 +12,11 @@ export interface ConfigEnvironmentVariables {
   QUEUE_HIGH_WATER: number;
   API_PORT: number;
   RECONNECTION_SERVICE_REQUIRED: boolean;
+  BLOCKCHAIN_SCAN_INTERVAL_MINUTES: number;
   GRAPH_ENVIRONMENT_TYPE: keyof EnvironmentType;
   GRAPH_ENVIRONMENT_DEV_CONFIG?: string;
   PROVIDER_ACCOUNT_SEED_PHRASE: string;
+  PROVIDER_ID: string;
 }
 
 /// Config service to get global app and provider-specific config values.
@@ -24,6 +26,10 @@ export class ConfigService {
 
   constructor(private nestConfigService: NestConfigService<ConfigEnvironmentVariables>) {
     this.logger = new Logger(this.constructor.name);
+  }
+
+  public getProviderId(): string {
+    return this.nestConfigService.get<string>('PROVIDER_ID')!;
   }
 
   public getQueueHighWater(): number {
@@ -36,6 +42,10 @@ export class ConfigService {
 
   public getReconnectionServiceRequired(): boolean {
     return this.nestConfigService.get<boolean>('RECONNECTION_SERVICE_REQUIRED')!;
+  }
+
+  public getBlockchainScanIntervalMinutes(): number {
+    return this.nestConfigService.get<number>('BLOCKCHAIN_SCAN_INTERVAL_MINUTES')!;
   }
 
   public getRedisUrl(): URL {

--- a/libs/common/src/config/config.service.ts
+++ b/libs/common/src/config/config.service.ts
@@ -11,6 +11,7 @@ export interface ConfigEnvironmentVariables {
   FREQUENCY_URL: URL;
   QUEUE_HIGH_WATER: number;
   API_PORT: number;
+  RECONNECTION_SERVICE_REQUIRED: boolean;
   GRAPH_ENVIRONMENT_TYPE: keyof EnvironmentType;
   GRAPH_ENVIRONMENT_DEV_CONFIG?: string;
   PROVIDER_ACCOUNT_SEED_PHRASE: string;
@@ -31,6 +32,10 @@ export class ConfigService {
 
   public getApiPort(): number {
     return this.nestConfigService.get<number>('API_PORT')!;
+  }
+
+  public getReconnectionServiceRequired(): boolean {
+    return this.nestConfigService.get<boolean>('RECONNECTION_SERVICE_REQUIRED')!;
   }
 
   public getRedisUrl(): URL {

--- a/libs/common/src/config/env.config.ts
+++ b/libs/common/src/config/env.config.ts
@@ -8,6 +8,7 @@ export const configModuleOptions: ConfigModuleOptions = {
     FREQUENCY_URL: Joi.string().uri().required(),
     QUEUE_HIGH_WATER: Joi.number().min(100).default(1000),
     API_PORT: Joi.number().min(0).default(3000),
+    RECONNECTION_SERVICE_REQUIRED: Joi.boolean().default(false),
     GRAPH_ENVIRONMENT_TYPE: Joi.string().required().valid('Mainnet', 'Rococo', 'Dev'),
     // GRAPH_ENVIRONMENT_DEV_CONFIG is optional, but if it is set, it must be a valid JSON string
     GRAPH_ENVIRONMENT_DEV_CONFIG: Joi.string().when('GRAPH_ENVIRONMENT_TYPE', {

--- a/libs/common/src/config/env.config.ts
+++ b/libs/common/src/config/env.config.ts
@@ -9,6 +9,9 @@ export const configModuleOptions: ConfigModuleOptions = {
     QUEUE_HIGH_WATER: Joi.number().min(100).default(1000),
     API_PORT: Joi.number().min(0).default(3000),
     RECONNECTION_SERVICE_REQUIRED: Joi.boolean().default(false),
+    BLOCKCHAIN_SCAN_INTERVAL_MINUTES: Joi.number()
+      .min(1)
+      .default(3 * 60),
     GRAPH_ENVIRONMENT_TYPE: Joi.string().required().valid('Mainnet', 'Rococo', 'Dev'),
     // GRAPH_ENVIRONMENT_DEV_CONFIG is optional, but if it is set, it must be a valid JSON string
     GRAPH_ENVIRONMENT_DEV_CONFIG: Joi.string().when('GRAPH_ENVIRONMENT_TYPE', {
@@ -25,5 +28,16 @@ export const configModuleOptions: ConfigModuleOptions = {
         }),
     }),
     PROVIDER_ACCOUNT_SEED_PHRASE: Joi.string().required(),
+    PROVIDER_ID: Joi.required().custom((value: string, helpers) => {
+      try {
+        const id = BigInt(value);
+        if (id < 0) {
+          throw new Error('Provider ID must be > 0');
+        }
+      } catch (e) {
+        return helpers.error('any.invalid');
+      }
+      return value;
+    }),
   }),
 };

--- a/libs/common/src/dtos/graph-update-job.interface.ts
+++ b/libs/common/src/dtos/graph-update-job.interface.ts
@@ -1,0 +1,47 @@
+import { MessageSourceId, ProviderId } from '@frequency-chain/api-augment/interfaces';
+import { AnyNumber } from '@polkadot/types/types';
+
+export const UpdateTransitiveGraphs = true;
+export const SkipTransitiveGraphs = false;
+
+// Note: DSNP IDs are u64 on Frequency, but since JS 'bigint' doesn't automatically
+//       serialize to JSON, we use strings here.
+export interface IGraphUpdateJob {
+  dsnpId: string;
+  providerId: string;
+  processTransitiveUpdates: boolean;
+
+  // Use for internal development/testing, can queue a job
+  // and have the processor complete, fail, retry, etc, based on the value
+  debugDisposition?: string;
+}
+
+export function createReconnectionJob(
+  dsnpIdValue: MessageSourceId | AnyNumber | string,
+  providerIdValue: ProviderId | AnyNumber | string,
+  processTransitiveUpdates: boolean,
+  debugDisposition?: string,
+): { key: string; data: IGraphUpdateJob } {
+  let dsnpId: string;
+  let providerId: string;
+  if (typeof dsnpIdValue !== 'string') {
+    dsnpId = dsnpIdValue.toString();
+  } else {
+    dsnpId = dsnpIdValue;
+  }
+  if (typeof providerIdValue !== 'string') {
+    providerId = providerIdValue.toString();
+  } else {
+    providerId = providerIdValue;
+  }
+
+  return {
+    key: `${dsnpId}:${providerId}:${processTransitiveUpdates}`,
+    data: {
+      dsnpId,
+      providerId,
+      processTransitiveUpdates,
+      debugDisposition,
+    },
+  };
+}

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -13,5 +13,6 @@ export * from './dtos/watch-graphs.dto';
 export * from './dtos/dsnp.graph.edge.dto';
 export * from './dtos/graph.change.request.reference';
 export * from './dtos/graph.update.job';
+export * from './dtos/graph-update-job.interface';
 export * from './utils/nonce.service';
 export * from './utils/queues';

--- a/libs/common/src/utils/queues.ts
+++ b/libs/common/src/utils/queues.ts
@@ -1,5 +1,10 @@
 export namespace QueueConstants {
   /**
+   * Name of the queue that has all reconnecting requests
+   */
+  export const RECONNECT_REQUEST_QUEUE = 'reconnectRequest';
+
+  /**
    * Name of the queue that has all incoming requests
    */
   export const GRAPH_CHANGE_REQUEST_QUEUE = 'graphChangeRequest';


### PR DESCRIPTION
## Details

Enabling an optional route for reconnecting social graphs and keeping graph states updated at given provider's end , this PR focuses on adding services that works together to enable reconnection

Details

- [x] Added blockchain scanner that queues job requests to reconnection queue 
- [x] Added a processor placehold and updated #17  where the said job from above queue will be processed and a new job will be sent to graph request processor in format it accepts to continue with further steps
