### PR TITLE
add provider webhook service to reterive user graphs/keys when reconn…

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -3,8 +3,6 @@ FREQUENCY_URL=ws://0.0.0.0:9944
 REDIS_URL=redis://0.0.0.0:6379
 QUEUE_HIGH_WATER=1000
 API_PORT=3000
-RECONNECTION_SERVICE_REQUIRED=false
-BLOCKCHAIN_SCAN_INTERVAL_MINUTES=5
 
 # Add the graph environment type. This can be 'Dev' or 'Rococo' or 'Mainnet'.
 GRAPH_ENVIRONMENT_TYPE=Dev
@@ -15,3 +13,15 @@ GRAPH_ENVIRONMENT_TYPE=Dev
 GRAPH_ENVIRONMENT_DEV_CONFIG='{"sdkMaxStaleFriendshipDays":100,"maxPageId":100,"dsnpVersions":["1.0"],"maxGraphPageSizeBytes":100,"maxKeyPageSizeBytes":100,"schemaMap":{"1":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"public"},"3":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"private"},"4":{"dsnpVersion":"1.0","connectionType":"friendship","privacyType":"private"}},"graphPublicKeySchemaId":5}'
 PROVIDER_ACCOUNT_SEED_PHRASE="//Ferdie"
 PROVIDER_ID=1
+
+# following are optional if reconnection service is is required
+PROVIDER_BASE_URL="http://localhost:3000" # this is optional if reconnection service is not required
+PROVIDER_ACCESS_TOKEN="api-key" # this is optional if reconnection service if PROVIDER_BASE_URL requires an access token
+PAGE_SIZE=100
+RECONNECTION_SERVICE_REQUIRED=true
+BLOCKCHAIN_SCAN_INTERVAL_MINUTES=5
+WEBHOOK_FAILURE_THRESHOLD=3
+HEALTH_CHECK_SUCCESS_THRESHOLD=10
+WEBHOOK_RETRY_INTERVAL_SECONDS=10
+HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS=10
+HEALTH_CHECK_MAX_RETRIES=4

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -12,7 +12,8 @@ import { GraphUpdatePublisherModule } from './graph_publisher/graph.publisher.pr
 import { GraphUpdatePublisherService } from './graph_publisher/graph.publisher.processor.service';
 import { GraphNotifierModule } from './graph_notifier/graph.monitor.processor.module';
 import { GraphNotifierService } from './graph_notifier/graph.monitor.processor.service';
-import { ProviderWebhookService } from '../../../libs/common/src';
+import { ProviderWebhookService, QueueConstants } from '../../../libs/common/src';
+import { BlockchainScannerService } from '../../../libs/common/src/blockchain/blockchain-scanner.service';
 
 @Module({
   imports: [
@@ -46,12 +47,26 @@ import { ProviderWebhookService } from '../../../libs/common/src';
       // disable throwing uncaughtException if an error event is emitted and it has no listeners
       ignoreErrors: false,
     }),
+    BullModule.registerQueue(
+      {
+        name: QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE,
+      },
+      {
+        name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
+      },
+      {
+        name: QueueConstants.GRAPH_CHANGE_NOTIFY_QUEUE,
+      },
+      {
+        name: QueueConstants.RECONNECT_REQUEST_QUEUE,
+      },
+    ),
     ScheduleModule.forRoot(),
     BlockchainModule,
     RequestProcessorModule,
     GraphUpdatePublisherModule,
     GraphNotifierModule,
   ],
-  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService, GraphNotifierService, ProviderWebhookService],
+  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService, GraphNotifierService, ProviderWebhookService, BlockchainScannerService],
 })
 export class WorkerModule {}

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -12,6 +12,7 @@ import { GraphUpdatePublisherModule } from './graph_publisher/graph.publisher.pr
 import { GraphUpdatePublisherService } from './graph_publisher/graph.publisher.processor.service';
 import { GraphNotifierModule } from './graph_notifier/graph.monitor.processor.module';
 import { GraphNotifierService } from './graph_notifier/graph.monitor.processor.service';
+import { ProviderWebhookService } from '../../../libs/common/src';
 
 @Module({
   imports: [
@@ -51,6 +52,6 @@ import { GraphNotifierService } from './graph_notifier/graph.monitor.processor.s
     GraphUpdatePublisherModule,
     GraphNotifierModule,
   ],
-  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService, GraphNotifierService],
+  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService, GraphNotifierService, ProviderWebhookService],
 })
 export class WorkerModule {}

--- a/env.template
+++ b/env.template
@@ -3,8 +3,6 @@ FREQUENCY_URL=ws://0.0.0.0:9944
 REDIS_URL=redis://0.0.0.0:6379
 QUEUE_HIGH_WATER=1000
 API_PORT=3000
-RECONNECTION_SERVICE_REQUIRED=false
-BLOCKCHAIN_SCAN_INTERVAL_MINUTES=5
 
 # Add the graph environment type. This can be 'Dev' or 'Rococo' or 'Mainnet'.
 GRAPH_ENVIRONMENT_TYPE=Dev
@@ -15,3 +13,15 @@ GRAPH_ENVIRONMENT_TYPE=Dev
 GRAPH_ENVIRONMENT_DEV_CONFIG='{"sdkMaxStaleFriendshipDays":100,"maxPageId":100,"dsnpVersions":["1.0"],"maxGraphPageSizeBytes":100,"maxKeyPageSizeBytes":100,"schemaMap":{"1":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"public"},"3":{"dsnpVersion":"1.0","connectionType":"follow","privacyType":"private"},"4":{"dsnpVersion":"1.0","connectionType":"friendship","privacyType":"private"}},"graphPublicKeySchemaId":5}'
 PROVIDER_ACCOUNT_SEED_PHRASE="//Alice"
 PROVIDER_ID=1
+
+# following are optional if reconnection service is is required
+PROVIDER_BASE_URL="http://localhost:3000" # this is optional if reconnection service is not required
+PROVIDER_ACCESS_TOKEN="api-key" # this is optional if reconnection service if PROVIDER_BASE_URL requires an access token
+PAGE_SIZE=100
+RECONNECTION_SERVICE_REQUIRED=true
+BLOCKCHAIN_SCAN_INTERVAL_MINUTES=5
+WEBHOOK_FAILURE_THRESHOLD=3
+HEALTH_CHECK_SUCCESS_THRESHOLD=10
+WEBHOOK_RETRY_INTERVAL_SECONDS=10
+HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS=10
+HEALTH_CHECK_MAX_RETRIES=4

--- a/libs/common/src/config/config.service.spec.ts
+++ b/libs/common/src/config/config.service.spec.ts
@@ -46,6 +46,14 @@ describe('GraphSericeConfig', () => {
     GRAPH_ENVIRONMENT_DEV_CONFIG: undefined,
     PROVIDER_ACCOUNT_SEED_PHRASE: undefined,
     PROVIDER_ID: undefined,
+    PROVIDER_BASE_URL: undefined,
+    PROVIDER_ACCESS_TOKEN: undefined,
+    WEBHOOK_FAILURE_THRESHOLD: undefined,
+    HEALTH_CHECK_SUCCESS_THRESHOLD: undefined,
+    WEBHOOK_RETRY_INTERVAL_SECONDS: undefined,
+    HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: undefined,
+    HEALTH_CHECK_MAX_RETRIES: undefined,
+    PAGE_SIZE: undefined,
   };
 
   beforeAll(() => {
@@ -139,6 +147,38 @@ describe('GraphSericeConfig', () => {
 
     it('should get provider id', () => {
       expect(graphServiceConfig.getProviderId()).toStrictEqual(ALL_ENV.PROVIDER_ID);
+    });
+
+    it('should get provider base url', () => {
+      expect(graphServiceConfig.providerBaseUrl?.toString()).toStrictEqual(ALL_ENV.PROVIDER_BASE_URL?.toString());
+    });
+
+    it('should get provider api token', () => {
+      expect(graphServiceConfig.providerApiToken).toStrictEqual(ALL_ENV.PROVIDER_ACCESS_TOKEN);
+    });
+
+    it('should get webhook failure threshold', () => {
+      expect(graphServiceConfig.getWebhookFailureThreshold()).toStrictEqual(parseInt(ALL_ENV.WEBHOOK_FAILURE_THRESHOLD as string, 10));
+    });
+
+    it('should get health check success threshold', () => {
+      expect(graphServiceConfig.getHealthCheckSuccessThreshold()).toStrictEqual(parseInt(ALL_ENV.HEALTH_CHECK_SUCCESS_THRESHOLD as string, 10));
+    });
+
+    it('should get webhook retry interval seconds', () => {
+      expect(graphServiceConfig.getWebhookRetryIntervalSeconds()).toStrictEqual(parseInt(ALL_ENV.WEBHOOK_RETRY_INTERVAL_SECONDS as string, 10));
+    });
+
+    it('should get health check max retry interval seconds', () => {
+      expect(graphServiceConfig.getHealthCheckMaxRetryIntervalSeconds()).toStrictEqual(parseInt(ALL_ENV.HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS as string, 10));
+    });
+
+    it('should get health check max retries', () => {
+      expect(graphServiceConfig.getHealthCheckMaxRetries()).toStrictEqual(parseInt(ALL_ENV.HEALTH_CHECK_MAX_RETRIES as string, 10));
+    });
+
+    it('should get page size', () => {
+      expect(graphServiceConfig.getPageSize()).toStrictEqual(parseInt(ALL_ENV.PAGE_SIZE as string, 10));
     });
   });
 });

--- a/libs/common/src/config/config.service.ts
+++ b/libs/common/src/config/config.service.ts
@@ -11,12 +11,20 @@ export interface ConfigEnvironmentVariables {
   FREQUENCY_URL: URL;
   QUEUE_HIGH_WATER: number;
   API_PORT: number;
-  RECONNECTION_SERVICE_REQUIRED: boolean;
-  BLOCKCHAIN_SCAN_INTERVAL_MINUTES: number;
   GRAPH_ENVIRONMENT_TYPE: keyof EnvironmentType;
   GRAPH_ENVIRONMENT_DEV_CONFIG?: string;
   PROVIDER_ACCOUNT_SEED_PHRASE: string;
   PROVIDER_ID: string;
+  RECONNECTION_SERVICE_REQUIRED: boolean;
+  BLOCKCHAIN_SCAN_INTERVAL_MINUTES: number;
+  PROVIDER_BASE_URL: string;
+  PROVIDER_ACCESS_TOKEN: string;
+  WEBHOOK_FAILURE_THRESHOLD: number;
+  HEALTH_CHECK_SUCCESS_THRESHOLD: number;
+  WEBHOOK_RETRY_INTERVAL_SECONDS: number;
+  HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: number;
+  HEALTH_CHECK_MAX_RETRIES: number;
+  PAGE_SIZE: number;
 }
 
 /// Config service to get global app and provider-specific config values.
@@ -26,6 +34,14 @@ export class ConfigService {
 
   constructor(private nestConfigService: NestConfigService<ConfigEnvironmentVariables>) {
     this.logger = new Logger(this.constructor.name);
+  }
+
+  public get providerBaseUrl(): URL {
+    return this.nestConfigService.get<URL>('PROVIDER_BASE_URL')!;
+  }
+
+  public get providerApiToken(): string | undefined {
+    return this.nestConfigService.get<string>('PROVIDER_ACCESS_TOKEN');
   }
 
   public getProviderId(): string {
@@ -74,5 +90,33 @@ export class ConfigService {
 
   public get frequencyUrl(): URL {
     return this.nestConfigService.get('FREQUENCY_URL')!;
+  }
+
+  public getHealthCheckMaxRetries(): number {
+    return this.nestConfigService.get<number>('HEALTH_CHECK_MAX_RETRIES')!;
+  }
+
+  public getHealthCheckMaxRetryIntervalSeconds(): number {
+    return this.nestConfigService.get<number>('HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS')!;
+  }
+
+  public getHealthCheckSuccessThreshold(): number {
+    return this.nestConfigService.get<number>('HEALTH_CHECK_SUCCESS_THRESHOLD')!;
+  }
+
+  public getWebhookFailureThreshold(): number {
+    return this.nestConfigService.get<number>('WEBHOOK_FAILURE_THRESHOLD')!;
+  }
+
+  public getWebhookRetryIntervalSeconds(): number {
+    return this.nestConfigService.get<number>('WEBHOOK_RETRY_INTERVAL_SECONDS')!;
+  }
+
+  public get webhookRetryIntervalSeconds(): number {
+    return this.nestConfigService.get('WEBHOOK_RETRY_INTERVAL_SECONDS')!;
+  }
+
+  public getPageSize(): number {
+    return this.nestConfigService.get('PAGE_SIZE')!;
   }
 }

--- a/libs/common/src/config/env.config.ts
+++ b/libs/common/src/config/env.config.ts
@@ -39,5 +39,16 @@ export const configModuleOptions: ConfigModuleOptions = {
       }
       return value;
     }),
+    PROVIDER_BASE_URL: Joi.string().uri().when('RECONNECTION_SERVICE_REQUIRED', {
+      is: true,
+      then: Joi.string().required(),
+    }),
+    PROVIDER_ACCESS_TOKEN: Joi.string().default(''),
+    WEBHOOK_FAILURE_THRESHOLD: Joi.number().min(1).default(3),
+    WEBHOOK_RETRY_INTERVAL_SECONDS: Joi.number().min(1).default(10),
+    HEALTH_CHECK_SUCCESS_THRESHOLD: Joi.number().min(1).default(10),
+    HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: Joi.number().min(1).default(64),
+    HEALTH_CHECK_MAX_RETRIES: Joi.number().min(0).default(20),
+    PAGE_SIZE: Joi.number().min(1).default(100),
   }),
 };

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -16,3 +16,4 @@ export * from './dtos/graph.update.job';
 export * from './dtos/graph-update-job.interface';
 export * from './utils/nonce.service';
 export * from './utils/queues';
+export * from './utils/provider-webhook.service';

--- a/libs/common/src/utils/provider-webhook.service.ts
+++ b/libs/common/src/utils/provider-webhook.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import axios, { AxiosInstance } from 'axios';
+import { MILLISECONDS_PER_SECOND } from 'time-constants';
+import { ConfigService } from '../config/config.service';
+
+const HEALTH_CHECK_TIMEOUT_NAME = 'health_check';
+
+@Injectable()
+export class ProviderWebhookService implements OnModuleDestroy {
+  private logger: Logger;
+
+  private failedHealthChecks = 0;
+
+  private successfulHealthChecks = 0;
+
+  private webhook: AxiosInstance;
+
+  public onModuleDestroy() {
+    try {
+      if (this.schedulerRegistry.doesExist('timeout', HEALTH_CHECK_TIMEOUT_NAME)) {
+        this.schedulerRegistry.deleteTimeout(HEALTH_CHECK_TIMEOUT_NAME);
+      }
+    } catch (e) {
+      this.logger.debug(`Caught error deleting timeouts: ${e}`);
+    }
+  }
+
+  constructor(
+    private configService: ConfigService,
+    private eventEmitter: EventEmitter2,
+    private schedulerRegistry: SchedulerRegistry,
+  ) {
+    this.logger = new Logger(this.constructor.name);
+    this.webhook = axios.create({
+      baseURL: this.configService.providerBaseUrl.toString(),
+    });
+
+    this.webhook.defaults.headers.common.Authorization = this.configService.providerApiToken;
+  }
+
+  public get providerApi(): AxiosInstance {
+    return this.webhook;
+  }
+
+  private async checkProviderWebhook() {
+    // Check webhook
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await this.webhook.get(`/health`);
+      this.successfulHealthChecks += 1;
+      this.failedHealthChecks = 0;
+    } catch (e: any) {
+      // Reset healthCheckSuccesses to 0 on failure. We will not go out of waiting for recovery until there
+      // are a number of sequential healthy responses equaling healthCheckSuccessesThreshold.
+      this.successfulHealthChecks = 0;
+      this.failedHealthChecks += 1;
+    }
+
+    if (this.failedHealthChecks > 0) {
+      if (this.failedHealthChecks >= this.configService.getHealthCheckMaxRetries()) {
+        this.logger.error(`FATAL ERROR: Failed to connect to provider webhook at '${this.configService.providerBaseUrl}' after ${this.failedHealthChecks} attempts.`);
+        this.eventEmitter.emit('shutdown');
+        return;
+      }
+      this.logger.warn(`Provider webhook failed health check ${this.failedHealthChecks} times`);
+      this.schedulerRegistry.deleteTimeout(HEALTH_CHECK_TIMEOUT_NAME);
+      this.schedulerRegistry.addTimeout(
+        HEALTH_CHECK_TIMEOUT_NAME,
+        setTimeout(
+          () => this.checkProviderWebhook(),
+          Math.min(2 ** (this.failedHealthChecks - 1) * MILLISECONDS_PER_SECOND, this.configService.getHealthCheckMaxRetryIntervalSeconds() * MILLISECONDS_PER_SECOND),
+        ),
+      );
+    } else if (this.successfulHealthChecks > 0) {
+      if (this.successfulHealthChecks >= this.configService.getHealthCheckSuccessThreshold()) {
+        this.logger.log(`Provider webhook responded to ${this.successfulHealthChecks} health checks; resuming queue`);
+        this.eventEmitter.emit('webhook.healthy');
+      } else {
+        this.logger.debug(`Provider webhook responded to health check (attempts: ${this.successfulHealthChecks})`);
+        this.schedulerRegistry.deleteTimeout(HEALTH_CHECK_TIMEOUT_NAME);
+        this.schedulerRegistry.addTimeout(
+          HEALTH_CHECK_TIMEOUT_NAME,
+          setTimeout(() => this.checkProviderWebhook(), this.configService.getWebhookRetryIntervalSeconds()),
+        );
+      }
+    }
+  }
+
+  @OnEvent('webhook.unhealthy')
+  private startWebhookHealthCheck() {
+    this.logger.debug('Received webhook.gone event; pausing queue and starting provider webhook health check');
+    this.failedHealthChecks = 0;
+    this.successfulHealthChecks = 0;
+    this.schedulerRegistry.addTimeout(
+      HEALTH_CHECK_TIMEOUT_NAME,
+      setTimeout(() => this.checkProviderWebhook(), 0),
+    );
+  }
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -27,6 +27,16 @@
       "compilerOptions": {
         "tsConfigPath": "apps/api/tsconfig.app.json"
       }
+    },
+    "worker": {
+      "type": "application",
+      "root": "apps/worker",
+      "entryFile": "main",
+      "sourceRoot": "apps/worker/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/worker/tsconfig.app.json"
+      
+      }
     }
   }
 }


### PR DESCRIPTION
## Details

If provider chooses to turn on reconnection service, a webhook service will be used to retrieve graphs of users whose graphs received events on frequency, this will ensure the correct provider graphs are retrieved along with keys