### PR TITLE
Add in redis list of endpoints watching for dsnp graph change

### DIFF
--- a/apps/api/src/api.controller.ts
+++ b/apps/api/src/api.controller.ts
@@ -72,8 +72,8 @@ export class ApiController {
   @ApiBody({ type: WatchGraphsDto })
   async watchGraphs(@Body() watchGraphsDto: WatchGraphsDto) {
     try {
-      // TODO: Uncomment this line once the ApiService is implemented
-      // const result = await this.apiService.watchGraphs(watchGraphsDto);
+      // eslint-disable-next-line no-await-in-loop
+      await this.apiService.watchGraphs(watchGraphsDto);
       return {
         status: HttpStatus.OK,
         data: 'Successfully started watching graphs',

--- a/apps/api/src/api.service.ts
+++ b/apps/api/src/api.service.ts
@@ -1,13 +1,13 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import Redis from 'ioredis';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { createHash } from 'crypto';
-import { GraphChangeRepsonseDto, ProviderGraphDto, QueueConstants } from '../../../libs/common/src';
+import { GraphChangeRepsonseDto, ProviderGraphDto, QueueConstants, WatchGraphsDto } from '../../../libs/common/src';
 
 @Injectable()
-export class ApiService {
+export class ApiService implements OnApplicationShutdown {
   private readonly logger: Logger;
 
   constructor(
@@ -15,6 +15,12 @@ export class ApiService {
     @InjectQueue(QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE) private graphChangeRequestQueue: Queue,
   ) {
     this.logger = new Logger(this.constructor.name);
+  }
+
+  onApplicationShutdown(signal?: string | undefined) {
+    this.cleanupOnShutdown().then(() => {
+      this.logger.log('Cleanup on shutdown completed.');
+    });
   }
 
   async enqueueRequest(request: ProviderGraphDto): Promise<GraphChangeRepsonseDto> {
@@ -29,9 +35,27 @@ export class ApiService {
     };
   }
 
+  async watchGraphs(watchGraphsDto: WatchGraphsDto): Promise<void> {
+    watchGraphsDto.dsnpIds.forEach(async (dsnpId) => {
+      const redisKey = `${QueueConstants.REDIS_WATCHER_PREFIX}:${dsnpId}`;
+      const redisValue = watchGraphsDto.webhookEndpoint;
+      // eslint-disable-next-line no-await-in-loop
+      await this.redis.rpush(redisKey, redisValue);
+    });
+  }
+
   // eslint-disable-next-line class-methods-use-this
   private calculateJobId(jobWithoutId: ProviderGraphDto): string {
     const stringVal = JSON.stringify(jobWithoutId);
     return createHash('sha1').update(stringVal).digest('base64url');
+  }
+
+  private async cleanupOnShutdown(): Promise<void> {
+    const keys = await this.redis.keys(`${QueueConstants.REDIS_WATCHER_PREFIX}:*`);
+
+    if (keys.length > 0) {
+      await this.redis.del(keys);
+      this.logger.log(`Removed keys on shutdown: ${keys.join(', ')}`);
+    }
   }
 }

--- a/apps/worker/src/graph_notifier/graph.monitor.processor.service.ts
+++ b/apps/worker/src/graph_notifier/graph.monitor.processor.service.ts
@@ -28,4 +28,11 @@ export class GraphNotifierService extends BaseConsumer {
       throw e;
     }
   }
+
+  async getWebhookList(dsnpId: string): Promise<string[]> {
+    const redisKey = `${QueueConstants.REDIS_WATCHER_PREFIX}:${dsnpId}`;
+    const redisList = await this.cacheManager.lrange(redisKey, 0, -1);
+
+    return redisList || [];
+  }
 }

--- a/libs/common/src/utils/queues.ts
+++ b/libs/common/src/utils/queues.ts
@@ -18,4 +18,9 @@ export namespace QueueConstants {
    * Name of the queue that processes graph change notifications
    */
   export const GRAPH_CHANGE_NOTIFY_QUEUE = 'graphChangeNotify';
+
+  /**
+   * Prefix for Redis keys that store webhook endpoints
+   */
+  export const REDIS_WATCHER_PREFIX = 'watcher';
 }

--- a/libs/common/src/utils/queues.ts
+++ b/libs/common/src/utils/queues.ts
@@ -22,5 +22,5 @@ export namespace QueueConstants {
   /**
    * Prefix for Redis keys that store webhook endpoints
    */
-  export const REDIS_WATCHER_PREFIX = 'watcher';
+  export const REDIS_WATCHER_PREFIX = 'graph-service-watcher';
 }


### PR DESCRIPTION
## Details

The api requesting watchers on graph change for specific dsnp id(s)

- [x] Set in redis a list of webhooks with prefixed dsnpid
- [x] update graph notifier to add a helper function which will be used to get webhooks to send notifications to
- [x] Clear up cache upon shutdown ?

part of #17 