### PR TITLE
add graph state manager to be used by request processor

### DIFF
--- a/apps/worker/src/request_processor/request.processor.module.ts
+++ b/apps/worker/src/request_processor/request.processor.module.ts
@@ -7,7 +7,7 @@ import { Module } from '@nestjs/common';
 import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { ConfigModule } from '../../../../libs/common/src/config/config.module';
 import { ConfigService } from '../../../../libs/common/src/config/config.service';
-import { QueueConstants } from '../../../../libs/common/src';
+import { QueueConstants, GraphStateManager } from '../../../../libs/common/src';
 import { RequestProcessorService } from './request.processor.service';
 
 @Module({
@@ -50,7 +50,7 @@ import { RequestProcessorService } from './request.processor.service';
       name: QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE,
     }),
   ],
-  providers: [RequestProcessorService],
+  providers: [RequestProcessorService, GraphStateManager],
   exports: [BullModule, RequestProcessorService],
 })
 export class RequestProcessorModule {}

--- a/apps/worker/src/request_processor/request.processor.service.ts
+++ b/apps/worker/src/request_processor/request.processor.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { Job } from 'bullmq';
 import Redis from 'ioredis';
 import { ConfigService } from '../../../../libs/common/src/config/config.service';
-import { ProviderGraphDto, QueueConstants } from '../../../../libs/common/src';
+import { GraphStateManager, ProviderGraphDto, QueueConstants } from '../../../../libs/common/src';
 import { BaseConsumer } from '../BaseConsumer';
 
 @Injectable()
@@ -13,6 +13,7 @@ export class RequestProcessorService extends BaseConsumer {
   constructor(
     @InjectRedis() private cacheManager: Redis,
     private configService: ConfigService,
+    private graphStateManagementService: GraphStateManager,
   ) {
     super();
   }

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -12,7 +12,7 @@ import { GraphUpdatePublisherModule } from './graph_publisher/graph.publisher.pr
 import { GraphUpdatePublisherService } from './graph_publisher/graph.publisher.processor.service';
 import { GraphNotifierModule } from './graph_notifier/graph.monitor.processor.module';
 import { GraphNotifierService } from './graph_notifier/graph.monitor.processor.service';
-import { ProviderWebhookService, QueueConstants } from '../../../libs/common/src';
+import { ProviderWebhookService, QueueConstants, GraphStateManager } from '../../../libs/common/src';
 import { BlockchainScannerService } from '../../../libs/common/src/services/blockchain-scanner.service';
 
 @Module({
@@ -67,6 +67,6 @@ import { BlockchainScannerService } from '../../../libs/common/src/services/bloc
     GraphUpdatePublisherModule,
     GraphNotifierModule,
   ],
-  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService, GraphNotifierService, ProviderWebhookService, BlockchainScannerService],
+  providers: [ConfigService, RequestProcessorService, GraphUpdatePublisherService, GraphNotifierService, ProviderWebhookService, BlockchainScannerService, GraphStateManager],
 })
 export class WorkerModule {}

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -18,4 +18,5 @@ export * from './services/nonce.service';
 export * from './utils/queues';
 export * from './services/provider-webhook.service';
 export * from './services/async_debouncer';
+export * from './services/graph-state-manager';
 export * from './constants';

--- a/libs/common/src/services/graph-state-manager.ts
+++ b/libs/common/src/services/graph-state-manager.ts
@@ -1,0 +1,181 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import {
+  Action,
+  Graph,
+  EnvironmentInterface,
+  GraphKeyPair,
+  GraphKeyType,
+  ImportBundle,
+  Update,
+  Config,
+  DevEnvironment,
+  EnvironmentType,
+  DsnpKeys,
+  DsnpPublicKey,
+  DsnpGraphEdge,
+  ConnectionType,
+  PrivacyType,
+} from '@dsnp/graph-sdk';
+import { ConfigService } from '../config/config.service';
+
+@Injectable()
+export class GraphStateManager implements OnApplicationBootstrap {
+  private graphState: Graph;
+
+  private environment: EnvironmentInterface; // Environment details
+
+  private schemaIds: { [key: string]: { [key: string]: number } };
+
+  private graphKeySchemaId: number;
+
+  private static graphStateFinalizer = new FinalizationRegistry((graphState: Graph) => {
+    if (graphState) {
+      graphState.freeGraphState();
+    }
+  });
+
+  public onApplicationBootstrap() {
+    if (!this.graphState) {
+      throw new Error('Unable to initialize schema ids');
+    }
+
+    const publicFollow = this.graphState.getSchemaIdFromConfig(this.environment, ConnectionType.Follow, PrivacyType.Public);
+    const privateFollow = this.graphState.getSchemaIdFromConfig(this.environment, ConnectionType.Follow, PrivacyType.Private);
+    const privateFriend = this.graphState.getSchemaIdFromConfig(this.environment, ConnectionType.Friendship, PrivacyType.Private);
+
+    this.graphKeySchemaId = this.graphState.getGraphConfig(this.environment).graphPublicKeySchemaId;
+
+    this.schemaIds = {
+      [ConnectionType.Follow]: {
+        [PrivacyType.Public]: publicFollow,
+        [PrivacyType.Private]: privateFollow,
+      },
+      [ConnectionType.Friendship]: {
+        [PrivacyType.Private]: privateFriend,
+      },
+    };
+  }
+
+  constructor(configService: ConfigService) {
+    const environmentType = configService.getGraphEnvironmentType();
+    if (environmentType === EnvironmentType.Dev.toString()) {
+      const configJson = configService.getGraphEnvironmentConfig();
+      const config: Config = JSON.parse(configJson);
+      const devEnvironment: DevEnvironment = { environmentType: EnvironmentType.Dev, config };
+      this.environment = devEnvironment;
+    } else {
+      this.environment = { environmentType: EnvironmentType[environmentType] };
+    }
+    this.graphState = new Graph(this.environment);
+
+    GraphStateManager.graphStateFinalizer.register(this, this.graphState);
+  }
+
+  public getGraphState(): Graph {
+    if (this.graphState) {
+      return this.graphState;
+    }
+    return {} as Graph;
+  }
+
+  public getGraphConfig(): Config {
+    if (this.graphState) {
+      return this.graphState.getGraphConfig(this.environment);
+    }
+    return {} as Config;
+  }
+
+  public getSchemaIdFromConfig(connectionType: ConnectionType, privacyType: PrivacyType): number {
+    return this.schemaIds[connectionType][privacyType] ?? 0;
+  }
+
+  public getGraphKeySchemaId(): number {
+    return this.graphKeySchemaId;
+  }
+
+  public static generateKeyPair(keyType: GraphKeyType): GraphKeyPair {
+    return Graph.generateKeyPair(keyType);
+  }
+
+  public static deserializeDsnpKeys(keys: DsnpKeys): DsnpPublicKey[] {
+    return Graph.deserializeDsnpKeys(keys);
+  }
+
+  public importUserData(payload: ImportBundle[]): boolean {
+    if (this.graphState) {
+      return this.graphState.importUserData(payload);
+    }
+    return false;
+  }
+
+  public applyActions(actions: Action[], ignoreExistingConnection: boolean): boolean {
+    if (this.graphState) {
+      return this.graphState.applyActions(actions, { ignoreExistingConnections: ignoreExistingConnection });
+    }
+    return false;
+  }
+
+  public exportGraphUpdates(): Update[] {
+    if (this.graphState) {
+      return this.graphState.exportUpdates();
+    }
+    return [];
+  }
+
+  public exportUserGraphUpdates(dsnpId: string): Update[] {
+    if (this.graphState) {
+      return this.graphState.exportUserGraphUpdates(dsnpId);
+    }
+
+    return [];
+  }
+
+  public removeUserGraph(dsnpUserId: string): boolean {
+    if (this.graphState) {
+      return this.graphState.removeUserGraph(dsnpUserId);
+    }
+    return false;
+  }
+
+  public graphContainsUser(dsnpUserId: string): boolean {
+    if (this.graphState) {
+      return this.graphState.containsUserGraph(dsnpUserId);
+    }
+    return false;
+  }
+
+  public getConnectionsForUserGraph(dsnpUserId: string, schemaId: number, includePending: boolean): DsnpGraphEdge[] {
+    if (this.graphState) {
+      return this.graphState.getConnectionsForUserGraph(dsnpUserId, schemaId, includePending);
+    }
+    return [];
+  }
+
+  public getConnectionWithoutKeys(): string[] {
+    if (this.graphState) {
+      return this.graphState.getConnectionsWithoutKeys();
+    }
+    return [];
+  }
+
+  public getOneSidedPrivateFriendshipConnections(dsnpUserId: string): DsnpGraphEdge[] {
+    if (this.graphState) {
+      return this.graphState.getOneSidedPrivateFriendshipConnections(dsnpUserId);
+    }
+    return [];
+  }
+
+  public getPublicKeys(dsnpUserId: string): DsnpPublicKey[] {
+    if (this.graphState) {
+      return this.graphState.getPublicKeys(dsnpUserId);
+    }
+    return [];
+  }
+
+  public forceCalculateGraphs(dsnpUserId: string): Update[] {
+    if (this.graphState) {
+      return this.graphState.forceCalculateGraphs(dsnpUserId);
+    }
+    return [];
+  }
+}


### PR DESCRIPTION
## Details

A graph state manager will be used by `request processor` which in turn will generate graph updates, return user graphs for given `dsnpId` which will be sent out by `graph notifier`

Part of #17 
Closes #3 