### PR TITLE
add processor for monitor

### DIFF
--- a/apps/api/src/api.service.ts
+++ b/apps/api/src/api.service.ts
@@ -34,7 +34,7 @@ export class ApiService implements OnApplicationShutdown {
       referenceId: this.calculateJobId(request),
       updateConnection: this.configService.getReconnectionServiceRequired(),
     };
-    const job = await this.graphChangeRequestQueue.add(`Request Job - ${data.referenceId}`, data, { jobId: data.referenceId, removeOnFail: false, removeOnComplete: 2000 }); // TODO: should come from queue configs
+    const job = await this.graphChangeRequestQueue.add(`Request Job - ${data.referenceId}`, data, { jobId: data.referenceId, removeOnFail: false, removeOnComplete: false }); // TODO: should come from queue configs
     this.logger.debug(job);
     return {
       referenceId: data.referenceId,

--- a/apps/worker/src/graph_notifier/graph.monitor.processor.module.ts
+++ b/apps/worker/src/graph_notifier/graph.monitor.processor.module.ts
@@ -9,9 +9,11 @@ import { ConfigModule } from '../../../../libs/common/src/config/config.module';
 import { ConfigService } from '../../../../libs/common/src/config/config.service';
 import { QueueConstants } from '../../../../libs/common/src';
 import { GraphNotifierService } from './graph.monitor.processor.service';
+import { BlockchainModule } from '../../../../libs/common/src/blockchain/blockchain.module';
 
 @Module({
   imports: [
+    BlockchainModule,
     ConfigModule,
     RedisModule.forRootAsync(
       {
@@ -46,9 +48,20 @@ import { GraphNotifierService } from './graph.monitor.processor.service';
       },
       inject: [ConfigService],
     }),
-    BullModule.registerQueue({
-      name: QueueConstants.GRAPH_CHANGE_NOTIFY_QUEUE,
-    }),
+    BullModule.registerQueue(
+      {
+        name: QueueConstants.GRAPH_CHANGE_NOTIFY_QUEUE,
+      },
+      {
+        name: QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE,
+      },
+      {
+        name: QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE,
+      },
+      {
+        name: QueueConstants.RECONNECT_REQUEST_QUEUE,
+      },
+    ),
   ],
   providers: [GraphNotifierService],
   exports: [BullModule, GraphNotifierService],

--- a/apps/worker/src/reconnection_processor/graph.reconnection.processor.service.ts
+++ b/apps/worker/src/reconnection_processor/graph.reconnection.processor.service.ts
@@ -45,7 +45,7 @@ export class GraphReconnectionService extends BaseConsumer {
         };
         this.graphChangeRequestQueuue.add(`Provider Graph Job - ${providerGraphJob.referenceId}`, providerGraphJob, {
           removeOnFail: false,
-          removeOnComplete: 2000,
+          removeOnComplete: false,
         });
         this.logger.debug(`Found ${graphConnections.length} connections for user ${job.data.dsnpId.toString()} from provider ${job.data.providerId.toString()}`);
       } catch (e) {

--- a/apps/worker/src/request_processor/request.processor.service.ts
+++ b/apps/worker/src/request_processor/request.processor.service.ts
@@ -236,7 +236,11 @@ export class RequestProcessorService extends BaseConsumer {
             if (isDelegatedConnection) {
               const { key: jobId, data } = createReconnectionJob(connection.dsnpId, providerId, SkipTransitiveGraphs);
               this.reconnectionQueue.remove(jobId);
-              this.reconnectionQueue.add(`graphUpdate:${data.dsnpId}`, data, { jobId });
+              this.reconnectionQueue.add(`graphUpdate:${data.dsnpId}`, data, {
+                jobId,
+                removeOnComplete: false,
+                removeOnFail: false,
+              });
             }
             break;
           }

--- a/libs/common/src/services/blockchain-scanner.service.ts
+++ b/libs/common/src/services/blockchain-scanner.service.ts
@@ -87,7 +87,11 @@ export class BlockchainScannerService implements OnApplicationBootstrap {
           if (job && ((await job.isCompleted()) || (await job.isFailed()))) {
             await job.retry();
           } else {
-            await this.reconnectionQueue.add(`graphUpdate:${data.dsnpId}`, data, { jobId });
+            await this.reconnectionQueue.add(`graphUpdate:${data.dsnpId}`, data, {
+              jobId,
+              removeOnComplete: false,
+              removeOnFail: false,
+            });
           }
         });
 


### PR DESCRIPTION
## Details

The tx processor will do the following
- [x] get the job from publisher with all details in ITxMonitor 
- [x] Process the tx hash in job to figure out if graph change made it to frequency
- [x] If it did not pass, based on errors coming from `stateful-storage-pallet` it will make a decision to either re-try or fail the job (mostly configuration issues needing fixes from deployment)
- [x] It everything looks good, it will remove successful jobs from respective queues

Part of #17 