### PR TITLE
send a generic graph change notification to registered webhooks

### DIFF
--- a/apps/worker/src/graph_notifier/graph.monitor.processor.module.ts
+++ b/apps/worker/src/graph_notifier/graph.monitor.processor.module.ts
@@ -7,7 +7,7 @@ import { Module } from '@nestjs/common';
 import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { ConfigModule } from '../../../../libs/common/src/config/config.module';
 import { ConfigService } from '../../../../libs/common/src/config/config.service';
-import { QueueConstants } from '../../../../libs/common/src';
+import { GraphStateManager, QueueConstants } from '../../../../libs/common/src';
 import { GraphNotifierService } from './graph.monitor.processor.service';
 import { BlockchainModule } from '../../../../libs/common/src/blockchain/blockchain.module';
 
@@ -63,7 +63,7 @@ import { BlockchainModule } from '../../../../libs/common/src/blockchain/blockch
       },
     ),
   ],
-  providers: [GraphNotifierService],
+  providers: [GraphNotifierService, GraphStateManager],
   exports: [BullModule, GraphNotifierService],
 })
 export class GraphNotifierModule {}

--- a/libs/common/src/dtos/graph.change.notification.dto.ts
+++ b/libs/common/src/dtos/graph.change.notification.dto.ts
@@ -1,0 +1,7 @@
+import { Update } from '@dsnp/graph-sdk';
+
+export class GraphChangeNotificationDto {
+  dsnpId: string;
+
+  update: Update;
+}

--- a/libs/common/src/dtos/graph.query.dto.ts
+++ b/libs/common/src/dtos/graph.query.dto.ts
@@ -1,4 +1,5 @@
 import { ArrayNotEmpty, ArrayUnique, IsArray, IsOptional, IsString } from 'class-validator';
+import { GraphKeyPairDto } from './graph.key.pair.dto';
 
 export class GraphsQueryParamsDto {
   @IsArray()
@@ -6,6 +7,11 @@ export class GraphsQueryParamsDto {
   @ArrayUnique()
   @IsString({ each: true })
   dsnpIds: string[];
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  grahKeyPairs?: GraphKeyPairDto[];
 
   @IsOptional()
   @IsString()

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -10,6 +10,7 @@ export * from './dtos/graph.key.pair.dto';
 export * from './dtos/connections.dto';
 export * from './dtos/watch-graphs.dto';
 export * from './dtos/dsnp.graph.edge.dto';
+export * from './dtos/graph.change.notification.dto';
 export * from './dtos/graph.change.request.reference';
 export * from './dtos/graph.update.job';
 export * from './interfaces/graph-update-job.interface';


### PR DESCRIPTION
## Details,

On successful round-trip of a change request, send the notification about graph change to registered webhooks listening for any changes on specific dsnp id

This is just a generic notification, as users of service will call `Get` graphs to get user graphs

part of #17 