### PR TITLE
handle stale hash for back to back same user jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean-graph-service:
 ###### Testing targets
 ######
 
-.PHONY: setuup
+.PHONY: setup
 setup:
 	@cd apps/api/test/setup && npm install && npm run main
 

--- a/apps/api/src/api.service.ts
+++ b/apps/api/src/api.service.ts
@@ -37,7 +37,14 @@ export class ApiService implements OnApplicationShutdown {
   }
 
   onApplicationShutdown(signal?: string | undefined) {
-    this.logger.log('Cleanup on shutdown completed.');
+    try {
+      this.redis.del(QueueConstants.REDIS_WATCHER_PREFIX);
+      this.redis.del(QueueConstants.DEBOUNCER_CACHE_KEY);
+      this.redis.del(QueueConstants.LAST_PROCESSED_DSNP_ID_KEY);
+      this.logger.log('Cleanup on shutdown completed.');
+    } catch (e) {
+      this.logger.error(`Error during cleanup on shutdown: ${e}`);
+    }
   }
 
   async enqueueRequest(request: ProviderGraphDto): Promise<GraphChangeRepsonseDto> {

--- a/apps/worker/src/request_processor/request.processor.service.ts
+++ b/apps/worker/src/request_processor/request.processor.service.ts
@@ -7,6 +7,7 @@ import { ConnectionType, ImportBundleBuilder, ConnectAction, DsnpKeys, Disconnec
 import { MessageSourceId, SchemaGrantResponse, ProviderId } from '@frequency-chain/api-augment/interfaces';
 import { Option, Vec } from '@polkadot/types';
 import { AnyNumber } from '@polkadot/types/types';
+import { MILLISECONDS_PER_SECOND } from 'time-constants';
 import { BaseConsumer } from '../BaseConsumer';
 import {
   ConnectionDto,
@@ -20,6 +21,7 @@ import {
 } from '../../../../libs/common/src';
 import { BlockchainService } from '../../../../libs/common/src/blockchain/blockchain.service';
 import { Direction } from '../../../../libs/common/src/dtos/direction.dto';
+import { SECONDS_PER_BLOCK } from '../graph_publisher/graph.publisher.processor.service';
 
 @Injectable()
 @Processor(QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE)
@@ -37,6 +39,15 @@ export class RequestProcessorService extends BaseConsumer {
   async process(job: Job<ProviderGraphUpdateJob, any, string>): Promise<void> {
     this.logger.log(`Processing job ${job.id} of type ${job.name}`);
     try {
+      const lastProcessedDsnpId = await this.cacheManager.get(QueueConstants.LAST_PROCESSED_DSNP_ID_KEY);
+      if (lastProcessedDsnpId && lastProcessedDsnpId === job.data.dsnpId) {
+        const blockDelay = SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
+        this.logger.debug(`Delaying processing of job ${job.id} for ${blockDelay}ms`);
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => {
+          setTimeout(r, blockDelay);
+        });
+      }
       const dsnpUserId: MessageSourceId = this.blockchainService.api.registry.createType('MessageSourceId', job.data.dsnpId);
       const providerId: ProviderId = this.blockchainService.api.registry.createType('ProviderId', job.data.providerId);
       this.graphStateManager.removeUserGraph(dsnpUserId.toString());
@@ -70,6 +81,7 @@ export class RequestProcessorService extends BaseConsumer {
 
       const reImported = await this.graphStateManager.importBundles(dsnpUserId, job.data.graphKeyPairs ?? []);
       if (reImported) {
+        this.cacheManager.set(QueueConstants.LAST_PROCESSED_DSNP_ID_KEY, job.data.dsnpId);
         this.logger.debug(`Re-imported bundles for ${dsnpUserId.toString()}`);
         // eslint-disable-next-line no-await-in-loop
         const userGraphExists = this.graphStateManager.graphContainsUser(dsnpUserId.toString());

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -47,7 +47,7 @@ services:
     container_name: frequency-manual-node
     volumes:
       - chainstorage:/data
-  graph-service-api:
+  api:
     build:
       context: .
       dockerfile: dev.Dockerfile
@@ -68,7 +68,7 @@ services:
     profiles: ['instant']
     restart: on-failure
 
-  graph-service-worker:
+  worker:
     build:
       context: .
       dockerfile: dev.Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - chainstorage:/data
 
   api:
-    image: amplicalabs/graph-service-service:api-0.0.2-rc2
+    image: amplicalabs/graph-service-service:api-0.0.2-rc3
     platform: linux/amd64
     ports:
       - 3000:3000
@@ -68,7 +68,7 @@ services:
     profiles: ['instant']
 
   worker:
-    image: amplicalabs/graph-service-service:api-0.0.2-rc2
+    image: amplicalabs/graph-service-service:api-0.0.2-rc3
     platform: linux/amd64
     env_file:
       - .env.dev

--- a/libs/common/src/utils/queues.ts
+++ b/libs/common/src/utils/queues.ts
@@ -28,4 +28,10 @@ export namespace QueueConstants {
    * Debouncer cache key
    */
   export const DEBOUNCER_CACHE_KEY = 'graph-service-debouncer';
+
+  /**
+   * Last processed dsnpId key for Redis
+   * @type {string}
+   */
+  export const LAST_PROCESSED_DSNP_ID_KEY: string = 'lastProcessedDsnpId';
 }

--- a/lua/updateLastProcessed.lua
+++ b/lua/updateLastProcessed.lua
@@ -1,0 +1,16 @@
+--[[
+Input:
+KEYS[1] lastProcessedDsnpId key
+ARGV[1] new lastProcessedDsnpId
+ARGV[2] key expire time in seconds
+Output:
+1 if the lastProcessedDsnpId was updated
+0 if the lastProcessedDsnpId was not updated
+]]
+local lastProcessedDsnpId = redis.call('GET', KEYS[1])
+if lastProcessedDsnpId ~= ARGV[1] then
+    redis.call('SETEX', KEYS[1], tonumber(ARGV[2]), ARGV[1])
+    return 1
+else
+    return 0
+end


### PR DESCRIPTION
## Details

TODO
- [x] think about race condition

For the same provider, a simple approach to make sure we dont encounter stale hashes is to put a check against last processed dsnpId, in such cases (assuming these are mostly back to back requests, but will work for requests coming sometime after another) but common theme is if we are processing same user graph back to back it could:

Happen that previous tx is not yet communicated to tx pool and we might not have latest hash.

We would delay by a block for such jobs to ensure we preemptively recover from stale hash for now


Open to suggestions