### PR TITLE
fix: pending extrinsic monitoring and capacity accounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 .pnp.*
 
 .idea/
+
+.vscode/
+

--- a/apps/api/src/api.service.ts
+++ b/apps/api/src/api.service.ts
@@ -182,9 +182,8 @@ export class ApiService implements BeforeApplicationShutdown {
     const graphs: UserGraphDto[] = [];
     // eslint-disable-next-line no-restricted-syntax
     for (const dsnpId of dsnpIds) {
-      const dsnpUserId: MessageSourceId = this.blockchainService.api.registry.createType('MessageSourceId', dsnpId);
       // eslint-disable-next-line no-await-in-loop
-      const graphEdges = await this.asyncDebouncerService.getGraphForDsnpId(dsnpUserId, privacyType, graphKeyPairs);
+      const graphEdges = await this.asyncDebouncerService.getGraphForDsnpId(dsnpId, privacyType, graphKeyPairs);
       graphs.push({
         dsnpId,
         dsnpGraphEdges: graphEdges,

--- a/apps/worker/src/graph_notifier/graph.monitor.processor.module.ts
+++ b/apps/worker/src/graph_notifier/graph.monitor.processor.module.ts
@@ -49,6 +49,9 @@ import * as QueueConstants from '#lib/utils/queues';
           removeOnComplete: true,
           removeOnFail: false,
           attempts: 3,
+          backoff: {
+            type: 'exponential',
+          },
         },
       },
       {

--- a/apps/worker/src/graph_publisher/graph.publisher.processor.service.ts
+++ b/apps/worker/src/graph_publisher/graph.publisher.processor.service.ts
@@ -96,7 +96,6 @@ export class GraphUpdatePublisherService extends BaseConsumer implements OnAppli
       const txMonitorJob: ITxMonitorJob = {
         id: job.data.referenceId,
         txHash: statefulStorageTxHash,
-        epoch: currentCapacityEpoch.toString(),
         lastFinalizedBlockHash,
         referencePublishJob: job.data,
       };
@@ -122,7 +121,7 @@ export class GraphUpdatePublisherService extends BaseConsumer implements OnAppli
    * @returns The hash of the submitted transaction.
    * @throws Error if the transaction hash is undefined or if there is an error processing the batch.
    */
-  async processSingleBatch(providerKeys: KeyringPair, tx: SubmittableExtrinsic<'rxjs', ISubmittableResult>): Promise<Hash> {
+  async processSingleBatch(providerKeys: KeyringPair, tx: SubmittableExtrinsic<'promise', ISubmittableResult>): Promise<Hash> {
     this.logger.debug(`Submitting tx of size ${tx.length}, nonce:${tx.nonce}, method: ${tx.method.section}.${tx.method.method}`);
     try {
       const ext = this.blockchainService.createExtrinsic(
@@ -133,7 +132,7 @@ export class GraphUpdatePublisherService extends BaseConsumer implements OnAppli
       );
       const nonce = await this.nonceService.getNextNonce();
       this.logger.debug(`Capacity Wrapped Extrinsic: ${ext}, nonce:${nonce}`);
-      const [txHash, _] = await ext.signAndSend(nonce);
+      const txHash = await ext.signAndSend(nonce);
       if (!txHash) {
         throw new Error('Tx hash is undefined');
       }

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,6 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { WorkerModule } from './worker.module';
 
+// Monkey-patch BigInt so that JSON.stringify will work
+// eslint-disable-next-line
+BigInt.prototype['toJSON'] = function () {
+  return this.toString();
+};
+
 async function bootstrap() {
   const app = await NestFactory.createApplicationContext(WorkerModule);
   app.enableShutdownHooks();

--- a/libs/common/src/blockchain/blockchain.service.spec.ts
+++ b/libs/common/src/blockchain/blockchain.service.spec.ts
@@ -1,17 +1,10 @@
-import { describe, it, beforeEach, jest, expect } from '@jest/globals';
-import { u32 } from '@polkadot/types';
 import { BlockchainService } from './blockchain.service';
 import { ConfigService } from '../config/config.service';
 
 describe('BlockchainService', () => {
-  let mockApi: any;
   let blockchainService: BlockchainService;
 
-  beforeEach(async () => {
-    mockApi = {
-      createType: jest.fn(),
-      query: jest.fn(),
-    };
+  beforeAll(async () => {
     const configService = {
       logger: jest.fn(),
       nestConfigService: jest.fn(),
@@ -40,21 +33,13 @@ describe('BlockchainService', () => {
     blockchainService = new BlockchainService(configService as unknown as ConfigService);
   });
 
-  describe('createExtrinsicCall', () => {
-    it('should return an extrinsic call', async () => {
-      const pallet = 'messages';
-      const extrinsic = 'addIpfsMessage';
-      const schemaId = 1;
-      const cid = 'QmRgJZmR6Z6yB5k9aLXjzJ6jG8L6tq4v4J9zQfDz7p3J9v';
-      const payloadLength = 100;
-    });
-  });
-
   describe('getCurrentCapacityEpochStart', () => {
     it('should return the current capacity epoch start', async () => {
       // Arrange
-      const expectedEpochStart: u32 = mockApi.createType('u32', 123);
-      const currentEpochInfo = { epochStart: expectedEpochStart };
+      const expectedEpochStart = { toNumber: () => 32 };
+      const currentEpochInfo = {
+        epochStart: expectedEpochStart,
+      };
 
       jest.spyOn(blockchainService, 'query').mockResolvedValue(currentEpochInfo);
 
@@ -62,7 +47,7 @@ describe('BlockchainService', () => {
       const result = await blockchainService.getCurrentCapacityEpochStart();
 
       // Assert
-      expect(result).toBe(expectedEpochStart);
+      expect(result).toBe(expectedEpochStart.toNumber());
     });
   });
 });

--- a/libs/common/src/blockchain/extrinsic.ts
+++ b/libs/common/src/blockchain/extrinsic.ts
@@ -1,78 +1,24 @@
-/**
- * These helpers return a map of events, some of which contain useful data, some of which don't.
- * Extrinsics that "create" records typically contain an ID of the entity they created, and this
- * would be a useful value to return. However, this data seems to be nested inside an array of arrays.
- *
- * Ex: schemaId = events["schemas.SchemaCreated"][<arbitrary_index>]
- *
- * To get the value associated with an event key, we would need to query inside that nested array with
- * a set of arbitrary indices. Should an object at any level of that querying be undefined, the helper
- * will throw an unchecked exception.
- *
- * To get type checking and cast a returned event as a specific event type, you can utilize TypeScripts
- * type guard functionality like so:
- *
- *      const msaCreatedEvent = events.defaultEvent;
- *      if (this.api.events.msa.MsaCreated.is(msaCreatedEvent)) {
- *          msaId = msaCreatedEvent.data.msaId;
- *      }
- *
- * Normally, I'd say the best experience is for the helper to return both the ID of the created entity
- * along with a map of emitted events. But in this case, returning that value will increase the complexity
- * of each helper, since each would have to check for undefined values at every lookup. So, this may be
- * a rare case when it is best to simply return the map of emitted events and trust the user to look them
- * up in the test.
- */
-
-import { ApiRx } from '@polkadot/api';
-import { SubmittableExtrinsic, ApiTypes, AugmentedEvent } from '@polkadot/api/types';
-import { Call, Event, EventRecord, Hash } from '@polkadot/types/interfaces';
-import { IsEvent } from '@polkadot/types/metadata/decorate/types';
-import { Codec, ISubmittableResult, AnyTuple } from '@polkadot/types/types';
-import { filter, firstValueFrom, map, pipe, tap } from 'rxjs';
+import { ApiPromise } from '@polkadot/api';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { Call, Hash } from '@polkadot/types/interfaces';
+import { ISubmittableResult } from '@polkadot/types/types';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { EventError } from './event-error';
 
-export type EventMap = Record<string, Event>;
+export class Extrinsic<T extends ISubmittableResult = ISubmittableResult> {
+  private extrinsic: SubmittableExtrinsic<'promise', T>;
 
-function eventKey(event: Event): string {
-  return `${event.section}.${event.method}`;
-}
-
-export type ParsedEventResult = [any, EventMap];
-
-export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C extends Codec[] = Codec[], N = unknown> {
-  private event?: IsEvent<C, N>;
-
-  private extrinsic: SubmittableExtrinsic<'rxjs', T>;
-
-  // private call: Call;
   private keys: KeyringPair;
 
-  public api: ApiRx;
+  public api: ApiPromise;
 
-  constructor(api: ApiRx, extrinsic: SubmittableExtrinsic<'rxjs', T>, keys: KeyringPair, targetEvent?: IsEvent<C, N>) {
+  constructor(api: ApiPromise, extrinsic: SubmittableExtrinsic<'promise', T>, keys: KeyringPair) {
     this.extrinsic = extrinsic;
     this.keys = keys;
-    this.event = targetEvent;
     this.api = api;
   }
 
-  public get targetEvent() {
-    return this.event;
-  }
-
-  public async signAndSend(nonce?: number): Promise<[Hash, EventMap]> {
-    const { status, events, txHash } = await firstValueFrom(this.extrinsic.signAndSend(this.keys, { nonce }));
-    if (status.isFinalized || status.isInBlock) {
-      const eventMap: EventMap = {};
-      events.forEach((record: EventRecord) => {
-        const { event } = record;
-        eventMap[eventKey(event)] = event;
-      });
-      return [txHash, eventMap];
-    }
-    return [txHash, {}];
+  public async signAndSend(nonce?: number): Promise<Hash> {
+    return this.extrinsic.signAndSend(this.keys, { nonce });
   }
 
   public getCall(): Call {

--- a/libs/common/src/dtos/graph.notifier.job.ts
+++ b/libs/common/src/dtos/graph.notifier.job.ts
@@ -4,7 +4,6 @@ import { GraphUpdateJob } from './graph.update.job';
 export interface ITxMonitorJob {
   id: string;
   txHash: Hash;
-  epoch: string;
   lastFinalizedBlockHash: BlockHash;
   referencePublishJob: GraphUpdateJob;
 }

--- a/libs/common/src/services/async_debouncer.ts
+++ b/libs/common/src/services/async_debouncer.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import Redis from 'ioredis';
 import { PrivacyType } from '@dsnp/graph-sdk';
-import { MessageSourceId, SchemaId } from '@frequency-chain/api-augment/interfaces';
 import * as QueueConstants from '../utils/queues';
 import { DsnpGraphEdge } from '../dtos/dsnp-graph-edge.dto';
 import { ConfigService } from '../config/config.service';
@@ -20,60 +19,47 @@ export class AsyncDebouncerService {
     this.logger = new Logger(this.constructor.name);
   }
 
-  public async getGraphForDsnpId(dsnpId: MessageSourceId, privacyType: string, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
+  public getGraphForDsnpId(dsnpId: string, privacyType: PrivacyType, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
     return this.debounceAsyncOperation(dsnpId, privacyType, graphKeyPairs);
   }
 
-  public async setGraphForSchemaId(dsnpId: MessageSourceId, schemaId: SchemaId, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
+  public setGraphForSchemaId(dsnpId: string, schemaId: number, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
     if (!schemaId) {
       throw new Error('Schema ID is required');
     }
-    const privacyType = this.graphStateManager.getPrivacyForSchema(schemaId.toNumber());
+    const privacyType = this.graphStateManager.getPrivacyForSchema(schemaId);
     return this.debounceAsyncOperation(dsnpId, privacyType, graphKeyPairs);
   }
 
-  async debounceAsyncOperation(dsnpId: MessageSourceId, privacyType: string, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
-    const cacheKey = this.getCacheKey(dsnpId.toString(), privacyType);
+  public async debounceAsyncOperation(dsnpId: string, privacyType: PrivacyType, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
+    const cacheKey = this.getCacheKey(dsnpId, privacyType);
 
     const cachedFuture = await this.redis.get(cacheKey);
     if (cachedFuture) {
-      this.logger.debug(`Async operation for key ${dsnpId} is already inflight`);
-      this.logger.debug(`Data: ${cachedFuture}`);
+      this.logger.debug(`Async operation for key ${dsnpId} is already inflight`, cachedFuture);
       const graphData: DsnpGraphEdge[] = JSON.parse(cachedFuture);
       if (graphData && graphData.length > 0) {
-        return Promise.resolve(graphData);
+        return graphData;
       }
     }
 
-    let privacyTypeValue = PrivacyType.Public;
-    if (privacyType === 'private') {
+    if (privacyType === PrivacyType.Private) {
       if (!graphKeyPairs || graphKeyPairs.length === 0) {
         throw new Error('Graph key pairs are required for private graph');
       }
-      privacyTypeValue = PrivacyType.Private;
     }
     let graphEdges: DsnpGraphEdge[] = [];
     try {
-      graphEdges = await this.graphStateManager.getConnectionsWithPrivacyType(dsnpId, privacyTypeValue, graphKeyPairs);
+      graphEdges = await this.graphStateManager.getConnectionsWithPrivacyType(dsnpId, privacyType, graphKeyPairs);
     } catch (err) {
-      this.logger.error(`Error getting graph edges for ${dsnpId} with privacy type ${privacyType}`);
-      this.logger.error(err);
-      return Promise.resolve(graphEdges);
+      this.logger.error(`Error getting graph edges for ${dsnpId} with privacy type ${privacyType}`, err);
+      return graphEdges;
     }
     const debounceTime = this.configService.getDebounceSeconds();
     await this.redis.setex(cacheKey, debounceTime, JSON.stringify(graphEdges));
     // Remove the graph from the graph state after the debounce time
-    this.scheduleRemoveUserGraph(dsnpId, debounceTime);
-    return Promise.resolve(graphEdges);
-  }
-
-  private async scheduleRemoveUserGraph(dsnpId: MessageSourceId, debounceTime: number): Promise<void> {
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        this.graphStateManager.removeUserGraph(dsnpId.toString());
-        resolve();
-      }, debounceTime * 1000);
-    });
+    setTimeout(() => this.graphStateManager.removeUserGraph(dsnpId.toString()), debounceTime * 1000);
+    return graphEdges;
   }
 
   private getCacheKey(key: string, privacyType: string): string {

--- a/libs/common/src/services/graph-state-manager.ts
+++ b/libs/common/src/services/graph-state-manager.ts
@@ -155,7 +155,7 @@ export class GraphStateManager implements OnApplicationBootstrap {
     return false;
   }
 
-  public async getConnectionsWithPrivacyType(dsnpUserId: MessageSourceId, privacyType: PrivacyType, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
+  public async getConnectionsWithPrivacyType(dsnpUserId: string, privacyType: PrivacyType, graphKeyPairs?: GraphKeyPairDto[]): Promise<DsnpGraphEdge[]> {
     const privateFollowSchemaId = this.schemaIds[ConnectionType.Follow][PrivacyType.Private];
     const privateFriendSchemaId = this.schemaIds[ConnectionType.Friendship][PrivacyType.Private];
     const publicFollowSchemaId = this.schemaIds[ConnectionType.Follow][PrivacyType.Public];
@@ -188,12 +188,12 @@ export class GraphStateManager implements OnApplicationBootstrap {
     return [];
   }
 
-  async importBundles(dsnpUserId: MessageSourceId, graphKeyPairs: GraphKeyPairDto[]): Promise<boolean> {
+  async importBundles(dsnpUserId: string, graphKeyPairs: GraphKeyPairDto[]): Promise<boolean> {
     const importBundles = await this.formImportBundles(dsnpUserId, graphKeyPairs);
     return this.importUserData(importBundles);
   }
 
-  async formImportBundles(dsnpUserId: MessageSourceId, graphKeyPairs: GraphKeyPairDto[]): Promise<ImportBundle[]> {
+  async formImportBundles(dsnpUserId: string, graphKeyPairs: GraphKeyPairDto[]): Promise<ImportBundle[]> {
     const publicFollowSchemaId = this.getSchemaIdFromConfig(ConnectionType.Follow, PrivacyType.Public);
     const privateFollowSchemaId = this.getSchemaIdFromConfig(ConnectionType.Follow, PrivacyType.Private);
     const privateFriendshipSchemaId = this.getSchemaIdFromConfig(ConnectionType.Friendship, PrivacyType.Private);


### PR DESCRIPTION
# Description
This PR fixes 2 bugs in the Worker related to extrinsic completion monitoring and capacity accounting:
- Ensures that ONLY the events associated with the target extrinsic are processed in a block for both capacity accounting and extrinsic success/failure/timeout determination
- Ensures the correct capacity epoch is used when recording the withdrawn capacity for an extrinsic

Closes #111 